### PR TITLE
Fix for sending notifications with priority 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ usage: pushover.sh <apikey> <userkey> <message> [options]
                                 0 - normal priority
                                 1 - bypass the user's quiet hours
                                 2 - require confirmation from the user
+  -e,  --expire SECONDS      Set expiration time for for notifications with priority 2 (default 180)
+  -r,  --retry COUNT         Set retry period for notifications with priority 2 (default 30)
   -s,  --sound SOUND         Notification sound to play with message
                                pushover - Pushover (default)
                                bike - Bike

--- a/pushover.sh
+++ b/pushover.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset
@@ -7,7 +7,8 @@ readonly API_URL="https://api.pushover.net/1/messages.json"
 readonly CONFIG_FILE="pushover-config"
 readonly DEFAULT_CONFIG="/etc/pushover/${CONFIG_FILE}"
 readonly USER_OVERRIDE="${HOME}/.pushover/${CONFIG_FILE}"
-
+readonly EXPIRE_DEFAULT=180
+readonly RETRY_DEFAULT=30
 
 showHelp()
 {
@@ -33,8 +34,8 @@ showHelp()
         echo "                                0 - normal priority"
         echo "                                1 - bypass the user's quiet hours"
         echo "                                2 - require confirmation from the user"
-        echo "  -e,  --expire SECONDS      Set expiration time for notifications with priority 2 (default 180)"
-        echo "  -r,  --retry COUNT         Set retry period for notifications with priority 2 (default 30)"
+        echo "  -e,  --expire SECONDS      Set expiration time for notifications with priority 2 (default ${EXPIRE_DEFAULT})"
+        echo "  -r,  --retry COUNT         Set retry period for notifications with priority 2 (default ${RETRY_DEFAULT})"
         echo "  -s,  --sound SOUND         Notification sound to play with message"
         echo "                               pushover - Pushover (default)"
         echo "                               bike - Bike"
@@ -170,10 +171,10 @@ done
 
 if [ $priority -eq 2 ]; then
   if [ -z "${expire:-}" ]; then
-    expire=181
+    expire=${EXPIRE_DEFAULT}
   fi
   if [ -z "${retry:-}" ]; then
-    retry=30
+    retry=${RETRY_DEFAULT}
   fi
 fi
 

--- a/pushover.sh
+++ b/pushover.sh
@@ -34,7 +34,7 @@ showHelp()
         echo "                                1 - bypass the user's quiet hours"
         echo "                                2 - require confirmation from the user"
         echo "  -E, --expire               Set expiration time for notifications with priority 2 (default 180)"
-		echo "  -R, --retry                Set retry period for notifications with priority 2 (default 30)"
+        echo "  -R, --retry                Set retry period for notifications with priority 2 (default 30)"
         echo "  -s,  --sound SOUND         Notification sound to play with message"
         echo "                               pushover - Pushover (default)"
         echo "                               bike - Bike"
@@ -146,15 +146,15 @@ do
       shift
       ;;
 
-	-E|--expire)
-		expire="${2:-}"
-		shift
-		;;
+    -E|--expire)
+        expire="${2:-}"
+        shift
+        ;;
 
-	-R|--retry)
-		retry="${2:-}"
-		shift
-		;;
+    -R|--retry)
+        retry="${2:-}"
+        shift
+        ;;
 
     -h|--help)
       showHelp
@@ -169,12 +169,12 @@ do
 done
 
 if [ $priority -eq 2 ]; then
-	if [ -z "${expire:-}" ]; then
-		expire=181
-	fi
-	if [ -z "${retry:-}" ]; then
-		retry=30
-	fi
+  if [ -z "${expire:-}" ]; then
+    expire=181
+  fi
+  if [ -z "${retry:-}" ]; then
+    retry=30
+  fi
 fi
 
 if [ -z "${api_token:-}" ]; then

--- a/pushover.sh
+++ b/pushover.sh
@@ -33,8 +33,8 @@ showHelp()
         echo "                                0 - normal priority"
         echo "                                1 - bypass the user's quiet hours"
         echo "                                2 - require confirmation from the user"
-        echo "  -E, --expire               Set expiration time for notifications with priority 2 (default 180)"
-        echo "  -R, --retry                Set retry period for notifications with priority 2 (default 30)"
+        echo "  -e,  --expire SECONDS      Set expiration time for notifications with priority 2 (default 180)"
+        echo "  -r,  --retry COUNT         Set retry period for notifications with priority 2 (default 30)"
         echo "  -s,  --sound SOUND         Notification sound to play with message"
         echo "                               pushover - Pushover (default)"
         echo "                               bike - Bike"
@@ -146,12 +146,12 @@ do
       shift
       ;;
 
-    -E|--expire)
+    -e|--expire)
         expire="${2:-}"
         shift
         ;;
 
-    -R|--retry)
+    -r|--retry)
         retry="${2:-}"
         shift
         ;;

--- a/pushover.sh
+++ b/pushover.sh
@@ -33,6 +33,8 @@ showHelp()
         echo "                                0 - normal priority"
         echo "                                1 - bypass the user's quiet hours"
         echo "                                2 - require confirmation from the user"
+        echo "  -E, --expire               Set expiration time for notifications with priority 2 (default 180)"
+		echo "  -R, --retry                Set retry period for notifications with priority 2 (default 30)"
         echo "  -s,  --sound SOUND         Notification sound to play with message"
         echo "                               pushover - Pushover (default)"
         echo "                               bike - Bike"
@@ -144,6 +146,16 @@ do
       shift
       ;;
 
+	-E|--expire)
+		expire="${2:-}"
+		shift
+		;;
+
+	-R|--retry)
+		retry="${2:-}"
+		shift
+		;;
+
     -h|--help)
       showHelp
       exit
@@ -156,6 +168,14 @@ do
   shift
 done
 
+if [ $priority -eq 2 ]; then
+	if [ -z "${expire:-}" ]; then
+		expire=181
+	fi
+	if [ -z "${retry:-}" ]; then
+		retry=30
+	fi
+fi
 
 if [ -z "${api_token:-}" ]; then
   echo "-t|--token must be set"
@@ -184,6 +204,8 @@ if [ -z "${attachment:-}" ]; then
   if [ "${url:-}" ]; then json="${json},\"url\":\"${url}\""; fi
   if [ "${url_title:-}" ]; then json="${json},\"url_title\":\"${url_title}\""; fi
   if [ "${priority:-}" ]; then json="${json},\"priority\":${priority}"; fi
+  if [ "${expire:-}" ]; then json="${json},\"expire\":${expire}"; fi
+  if [ "${retry:-}" ]; then json="${json},\"retry\":${retry}"; fi
   if [ "${sound:-}" ]; then json="${json},\"sound\":\"${sound}\""; fi
   json="${json}}"
 


### PR DESCRIPTION
To send notifications with priority 2 two additional parameters should be set (expire and retry).

This patch adds support for these parameters.