### PR TITLE
Let the script fail when pushover return 4xx

### DIFF
--- a/pushover.sh
+++ b/pushover.sh
@@ -233,12 +233,12 @@ if [ -z "${attachment:-}" ]; then
   if [ "${sound:-}" ]; then json="${json},\"sound\":\"${sound}\""; fi
   json="${json}}"
 
-  curl -s ${HIDE_REPLY:+ -o /dev/null} \
+  curl --fail -s ${HIDE_REPLY:+ -o /dev/null} \
     -H "Content-Type: application/json" \
     -d "${json}" \
     "${API_URL}" 2>&1
 else
-  curl -s ${HIDE_REPLY:+ -o /dev/null} \
+  curl --fail -s ${HIDE_REPLY:+ -o /dev/null} \
     --form-string "token=${api_token}" \
     --form-string "user=${user_key}" \
     --form-string "message=${message}" \


### PR DESCRIPTION
This PR adds the `--fail` parameter to curl to let the script fail, whenever the api returns a 4xx http status code.