### PR TITLE
Allow passing message as positional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ title="title for specific user"
 Send a simple "This is a test" message to all devices using the stored configuration in either **/etc/default/pushover-config** or **$HOME/.pushover/pushover-config**
 
 ```
-pushover.sh -m "This is a test"
+pushover.sh "This is a test"
 ```
 
 Send a simple "This is a test" message to all devices using the specified API token and user key

--- a/pushover.sh
+++ b/pushover.sh
@@ -19,7 +19,7 @@ showHelp()
         echo
         echo "NOTE: This script requires an account at http://www.pushover.net"
         echo
-        echo "usage: ${script} <-t|--token apikey> <-u|--user userkey> <[-m|--message ]message> [options] [message]"
+        echo "usage: ${script} <-t|--token apikey> <-u|--user userkey> <[-m|--message ]message> [options]"
         echo
         echo "  -t,  --token APIKEY        The pushover.net API Key for your application"
         echo "  -u,  --user USERKEY        Your pushover.net user key"

--- a/pushover.sh
+++ b/pushover.sh
@@ -19,7 +19,7 @@ showHelp()
         echo
         echo "NOTE: This script requires an account at http://www.pushover.net"
         echo
-        echo "usage: ${script} <-t|--token apikey> <-u|--user userkey> <-m|--message message> [options]"
+        echo "usage: ${script} <-t|--token apikey> <-u|--user userkey> <[-m|--message ]message> [options] [message]"
         echo
         echo "  -t,  --token APIKEY        The pushover.net API Key for your application"
         echo "  -u,  --user USERKEY        Your pushover.net user key"
@@ -68,6 +68,9 @@ showHelp()
         echo
         echo "  ${script} -t xxxxxxxxxx -u yyyyyyyyyy -m \"This is a test\""
         echo "  Sends a simple \"This is a test\" message to all devices."
+        echo
+        echo "  ${script} \"This is a test\""
+        echo "  Sends a simple \"This is a test\" message with all other options being set through the configuration files."
         echo
         echo "  ${script} -t xxxxxxxxxx -u yyyyyyyyyy -m \"This is a test\" -T \"Test Title\""
         echo "  Sends a simple \"This is a test\" message with the title \"Test Title\" to all devices."
@@ -179,6 +182,7 @@ do
       ;;
 
     *)
+      message="${1:-}"
       ;;
   esac
 


### PR DESCRIPTION
This allows to simplify calls to the script when most options are set in the configuration.

Then a simple message can be sent like that:
`pushover.sh "this is the message"`